### PR TITLE
Merge upstream updates up to 8.x-1.1

### DIFF
--- a/src/SubpathautoServiceProvider.php
+++ b/src/SubpathautoServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\subpathauto;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\Core\Update\UpdateKernel;
+
+/**
+ * Defines a service provider for the Subpathauto module.
+ */
+class SubpathautoServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    // The alias-based processor requires the path_alias entity schema to be
+    // installed, so we prevent it from being registered to the path processor
+    // manager. We do this by removing the tags that the compiler pass looks
+    // for. This means that the URL generator can safely be used during the
+    // database update process.
+    if ($container->get('kernel') instanceof UpdateKernel && $container->hasDefinition('path_processor_subpathauto')) {
+      $container->getDefinition('path_processor_subpathauto')
+        ->clearTag('path_processor_inbound')
+        ->clearTag('path_processor_outbound');
+    }
+  }
+
+}

--- a/subpathauto.info.yml
+++ b/subpathauto.info.yml
@@ -1,6 +1,6 @@
 name: Sub-pathauto
 type: module
 description: Provides support for extending sub-paths of URL aliases.
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 configure: subpathauto.admin_settings
 

--- a/subpathauto.services.yml
+++ b/subpathauto.services.yml
@@ -1,7 +1,7 @@
 services:
   path_processor_subpathauto:
     class: Drupal\subpathauto\PathProcessor
-    arguments: ['@path_processor_alias', '@language_manager', '@config.factory']
+    arguments: ['@path_alias.path_processor', '@language_manager', '@config.factory']
     tags:
       - { name: path_processor_inbound, priority: 50 }
       - { name: path_processor_outbound, priority: 50 }

--- a/tests/src/Functional/SubPathautoFunctionalTest.php
+++ b/tests/src/Functional/SubPathautoFunctionalTest.php
@@ -3,12 +3,11 @@
 namespace Drupal\Tests\subpathauto\Functional;
 
 use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 use Drupal\Tests\BrowserTestBase;
 
 /**
- * Class SubPathautoFunctionalTest
+ * Class SubPathautoFunctionalTest.
+ *
  * @group subpathauto
  */
 class SubPathautoFunctionalTest extends BrowserTestBase {
@@ -16,7 +15,19 @@ class SubPathautoFunctionalTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['subpathauto', 'node', 'user', 'block', 'text', 'language'];
+  public static $modules = [
+    'subpathauto',
+    'node',
+    'user',
+    'block',
+    'text',
+    'language',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
 
   /**
    * {@inheritdoc}
@@ -35,8 +46,15 @@ class SubPathautoFunctionalTest extends BrowserTestBase {
     // we have to rebuild it.
     $this->rebuildContainer();
 
-    $alias_storage = $this->container->get('path.alias_storage');
-    $alias_storage->save('/node/1', '/kittens');
+    $aliasStorage = \Drupal::entityTypeManager()
+      ->getStorage('path_alias');
+
+    $path_alias = $aliasStorage->create([
+      'path' => '/node/1',
+      'alias' => '/kittens',
+    ]);
+    $path_alias->save();
+
     $alias_white_list = $this->container->get('path.alias_whitelist');
     $alias_white_list->set('node', TRUE);
 

--- a/tests/src/Kernel/SubPathautoKernelTest.php
+++ b/tests/src/Kernel/SubPathautoKernelTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\subpathauto\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
-use Drupal\simpletest\UserCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\user\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -20,12 +20,12 @@ class SubPathautoKernelTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['system', 'subpathauto', 'node', 'user'];
-
-  /**
-   * @var \Drupal\Core\Path\AliasStorage
-   */
-  protected $aliasStorage;
+  public static $modules = [
+    'system',
+    'subpathauto',
+    'node',
+    'user',
+  ];
 
   /**
    * @var \Drupal\Core\Path\AliasWhitelistInterface
@@ -61,12 +61,20 @@ class SubPathautoKernelTest extends KernelTestBase {
     ]);
     $type->save();
 
-    $this->aliasStorage = $this->container->get('path.alias_storage');
     $this->sut = $this->container->get('path_processor_subpathauto');
     $this->aliasWhiteList = $this->container->get('path.alias_whitelist');
 
     Node::create(['type' => 'page', 'title' => 'test'])->save();
-    $this->aliasStorage->save('/node/1', '/kittens');
+
+    $aliasStorage = \Drupal::entityTypeManager()
+      ->getStorage('path_alias');
+
+    $path_alias = $aliasStorage->create([
+      'path' => '/node/1',
+      'alias' => '/kittens',
+    ]);
+    $path_alias->save();
+
     $this->aliasWhiteList->set('node', TRUE);
 
     User::create(['uid' => 0, 'name' => 'anonymous user'])->save();

--- a/tests/src/Kernel/SubPathautoKernelTest.php
+++ b/tests/src/Kernel/SubPathautoKernelTest.php
@@ -6,6 +6,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\simpletest\UserCreationTrait;
+use Drupal\user\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -47,6 +48,9 @@ class SubPathautoKernelTest extends KernelTestBase {
     $this->installSchema('system', 'sequences');
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
+    if ($this->container->get('entity_type.manager')->hasDefinition('path_alias')) {
+      $this->installEntitySchema('path_alias');
+    }
 
     $this->installConfig('subpathauto');
 
@@ -64,6 +68,8 @@ class SubPathautoKernelTest extends KernelTestBase {
     Node::create(['type' => 'page', 'title' => 'test'])->save();
     $this->aliasStorage->save('/node/1', '/kittens');
     $this->aliasWhiteList->set('node', TRUE);
+
+    User::create(['uid' => 0, 'name' => 'anonymous user'])->save();
   }
 
   /**

--- a/tests/src/Unit/SubPathautoTest.php
+++ b/tests/src/Unit/SubPathautoTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\subpathauto\Unit;
 
-use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Language\Language;
 use Drupal\Core\Url;
 use Drupal\Tests\UnitTestCase;
@@ -16,7 +15,7 @@ use Drupal\subpathauto\PathProcessor;
 class SubPathautoTest extends UnitTestCase {
 
   /**
-   * @var \Drupal\Core\PathProcessor\PathProcessorAlias|\PHPUnit_Framework_MockObject_MockObject
+   * @var \Drupal\path_alias\PathProcessor\AliasPathProcessor|\PHPUnit_Framework_MockObject_MockObject
    */
   protected $aliasProcessor;
 
@@ -65,20 +64,20 @@ class SubPathautoTest extends UnitTestCase {
   public function setUp() {
     parent::setUp();
 
-    $this->aliasProcessor = $this->getMockBuilder('Drupal\Core\PathProcessor\PathProcessorAlias')
+    $this->aliasProcessor = $this->getMockBuilder('Drupal\path_alias\PathProcessor\AliasPathProcessor')
       ->disableOriginalConstructor()
       ->getMock();
 
-    $this->languageManager = $this->getMock('Drupal\Core\Language\LanguageManagerInterface');
+    $this->languageManager = $this->createMock('Drupal\Core\Language\LanguageManagerInterface');
     $this->languageManager->expects($this->any())
       ->method('getCurrentLanguage')
       ->willReturn(new Language(Language::$defaultValues));
 
-    $this->pathValidator = $this->getMock('Drupal\Core\Path\PathValidatorInterface');
+    $this->pathValidator = $this->createMock('Drupal\Core\Path\PathValidatorInterface');
 
-    $this->subPathautoSettings = $this->getMock('Drupal\Core\Config\ConfigBase');
+    $this->subPathautoSettings = $this->createMock('Drupal\Core\Config\ConfigBase');
 
-    $this->configFactory = $this->getMock('Drupal\Core\Config\ConfigFactoryInterface');
+    $this->configFactory = $this->createMock('Drupal\Core\Config\ConfigFactoryInterface');
     $this->configFactory->expects($this->any())
       ->method('get')
       ->with('subpathauto.settings')
@@ -94,7 +93,7 @@ class SubPathautoTest extends UnitTestCase {
   public function testInboundSubPath() {
     $this->aliasProcessor->expects($this->any())
       ->method('processInbound')
-      ->will($this->returnCallback([$this, 'pathAliasCallback']));
+      ->willReturnCallback([$this, 'pathAliasCallback']);
     $this->pathValidator->expects($this->any())
       ->method('getUrlIfValidWithoutAccessCheck')
       ->willReturn(new Url('any_route'));
@@ -142,7 +141,7 @@ class SubPathautoTest extends UnitTestCase {
 
     $this->aliasProcessor->expects($this->any())
       ->method('processInbound')
-      ->will($this->returnCallback([$this, 'pathAliasCallback']));
+      ->willReturnCallback([$this, 'pathAliasCallback']);
 
     // Subpath shouldn't be processed since the iterations has been limited.
     $processed = $this->sut->processInbound('/content/first-node/first/second/third/fourth', Request::create('/content/first-node/first/second/third/fourth'));
@@ -169,7 +168,7 @@ class SubPathautoTest extends UnitTestCase {
   public function testOutboundSubPath() {
     $this->aliasProcessor->expects($this->any())
       ->method('processOutbound')
-      ->will($this->returnCallback([$this, 'aliasByPathCallback']));
+      ->willReturnCallback([$this, 'aliasByPathCallback']);
     $this->subPathautoSettings->expects($this->atLeastOnce())
       ->method('get')
       ->willReturn(0);
@@ -209,7 +208,7 @@ class SubPathautoTest extends UnitTestCase {
 
     $this->aliasProcessor->expects($this->any())
       ->method('processOutbound')
-      ->will($this->returnCallback([$this, 'aliasByPathCallback']));
+      ->willReturnCallback([$this, 'aliasByPathCallback']);
 
     // Subpath shouldn't be processed since the iterations has been limited.
     $processed = $this->sut->processOutbound('/node/1/first/second/third/fourth');


### PR DESCRIPTION
Updates our patched version with the latest on the upstream repo, up to 8.x-1.1. Command history for reference:

```
$ git remote -v
drupal  git@git.drupal.org:project/subpathauto.git (fetch)
drupal  git@git.drupal.org:project/subpathauto.git (push)
origin  https://github.com/nbc-bravo/drupal-subpathauto (fetch)
origin  https://github.com/nbc-bravo/drupal-subpathauto (push)
$ git checkout  8.x-1.1
$ git merge patched
$ git checkout -b subpathauto-update-8.x-1.1
$ git push origin subpathauto-update-8.x-1.1
```